### PR TITLE
fix: 404 routes with vercel deployment

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## What

Fixes routing issues with the Vercel deployment of the motion website.

## Why

Essentially, Vite knows how to handle client-side routing locally, but Vercel's servers will look for a corresponding file matching the route (e.g. `/about` requires a matching `/about.html` file), returning 404 since the file does not exist (because it's handled client-side). This change fixes it by always serving `index.html` and allowing React Router to handle all client-side routes as expected.

Reference: https://stackoverflow.com/a/79548499