### PR TITLE
fix: stretching navbar in workspace layout

### DIFF
--- a/frontend/src/components/workspace/files/files.tsx
+++ b/frontend/src/components/workspace/files/files.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { useStore } from '@tanstack/react-store'
 import { FileCard, NoFilesFound } from './file'
 import { FilesPageHeader } from './header'
-import PageContent from '@/components/workspace/layout/page-content'
 import FilePicker from '@/components/workspace/files/file-picker'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { fileItemsStore } from '@/store/files/files-store'
@@ -27,7 +26,7 @@ export default function WorkspaceFiles() {
   })
 
   return (
-    <PageContent>
+    <>
       <FilePicker />
       <FilesPageHeader
         searchQuery={searchQuery}
@@ -60,6 +59,6 @@ export default function WorkspaceFiles() {
           </TabsContent>
         </div>
       </Tabs>
-    </PageContent>
+    </>
   )
 }

--- a/frontend/src/components/workspace/layout/navbar.tsx
+++ b/frontend/src/components/workspace/layout/navbar.tsx
@@ -4,7 +4,7 @@ export default function AppNavbar() {
   return (
     <nav
       className="fixed top-0 right-0 left-0 flex items-center justify-between
-      border-b border-sidebar-border p-5 bg-background z-10 md:left-[var(--sidebar-length,_16rem)]"
+      border-b border-sidebar-border p-5 bg-background z-10 md:left-[16rem]"
     >
       <span className="font-semibold">CPSC 491's Workspace</span>
       <div>

--- a/frontend/src/components/workspace/layout/navbar.tsx
+++ b/frontend/src/components/workspace/layout/navbar.tsx
@@ -4,7 +4,7 @@ export default function AppNavbar() {
   return (
     <nav
       className="fixed top-0 right-0 left-0 flex items-center justify-between
-      border-b border-sidebar-border p-5 bg-background z-10 md:left-[16rem]"
+      border-b border-sidebar-border p-5 bg-background z-10 md:left-[var(--sidebar-length,_16rem)]"
     >
       <span className="font-semibold">CPSC 491's Workspace</span>
       <div>

--- a/frontend/src/components/workspace/layout/navbar.tsx
+++ b/frontend/src/components/workspace/layout/navbar.tsx
@@ -2,7 +2,10 @@ import { User } from 'lucide-react'
 
 export default function AppNavbar() {
   return (
-    <nav className="w-full flex items-center justify-between border-b border-sidebar-border p-5">
+    <nav
+      className="fixed top-0 right-0 left-0 flex items-center justify-between
+      border-b border-sidebar-border p-5 bg-background z-10 md:left-[16rem]"
+    >
       <span className="font-semibold">CPSC 491's Workspace</span>
       <div>
         <User />

--- a/frontend/src/components/workspace/layout/page-content.tsx
+++ b/frontend/src/components/workspace/layout/page-content.tsx
@@ -5,5 +5,5 @@ export default function PageContent({
 }: {
   children: React.ReactNode
 }) {
-  return <main className="flex flex-col w-full gap-8">{children}</main>
+  return <main className="flex pt-16 flex-col w-full gap-8">{children}</main>
 }

--- a/frontend/src/components/workspace/manager/board.tsx
+++ b/frontend/src/components/workspace/manager/board.tsx
@@ -8,7 +8,7 @@ export const Board: React.FC = () => {
   const { columns } = useStore(kanbanStore)
   return (
     <KanbanDndProvider>
-      <div className="flex-1 overflow-x-auto overflow-y-hidden p-6">
+      <div className="flex-1 overflow-x-auto overflow-y-hidden p-6 min-h-0">
         <div className="flex gap-6 h-full min-w-max">
           {columns.map((column) => (
             <DroppableColumn key={column.id} column={column} />

--- a/frontend/src/components/workspace/manager/manager.tsx
+++ b/frontend/src/components/workspace/manager/manager.tsx
@@ -1,14 +1,13 @@
 import { Board } from './board'
 import { ManagerHeader } from './header'
 import EditTask from './edit'
-import PageContent from '@/components/workspace/layout/page-content'
 
 export default function WorkspaceManager() {
   return (
-    <PageContent>
+    <>
       <ManagerHeader />
       <Board />
       <EditTask />
-    </PageContent>
+    </>
   )
 }

--- a/frontend/src/routes/workspace/$workspaceId/notes/index.tsx
+++ b/frontend/src/routes/workspace/$workspaceId/notes/index.tsx
@@ -42,7 +42,6 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { MultiSelectCombobox } from '@/components/ui/multi-select-combobox'
-import PageContent from '@/components/workspace/layout/page-content'
 import { noteActions, notesStore } from '@/store/notes-store'
 
 interface NoteCardProps {
@@ -274,7 +273,7 @@ function NotesListPage() {
   }, [notes, searchTerm, sortBy])
 
   return (
-    <PageContent>
+    <>
       {/* Header */}
       <div className="p-8">
         <div className="flex justify-between items-center mb-4 gap-4">
@@ -341,6 +340,6 @@ function NotesListPage() {
           </div>
         )}
       </div>
-    </PageContent>
+    </>
   )
 }

--- a/frontend/src/routes/workspace/$workspaceId/route.tsx
+++ b/frontend/src/routes/workspace/$workspaceId/route.tsx
@@ -2,6 +2,7 @@ import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import AppNavbar from '@/components/workspace/layout/navbar'
 import AppSidebar from '@/components/workspace/layout/sidebar'
+import PageContent from '@/components/workspace/layout/page-content'
 
 export const Route = createFileRoute('/workspace/$workspaceId')({
   component: WorkspaceLayout,
@@ -16,7 +17,9 @@ function WorkspaceLayout() {
         <AppSidebar workspaceId={workspaceId} />
         <div className="w-full">
           <AppNavbar />
-          <Outlet />
+          <PageContent>
+            <Outlet />
+          </PageContent>
         </div>
       </SidebarProvider>
     </>


### PR DESCRIPTION
Fixes #44.

## Changes

- Makes `<AppNavbar />` fixed to the top of the page (inside the workspace layout)
- Shifts the navbar to the left by the width of the sidebar if it's present (otherwise it will just make its width 100%)
- (Other minor change) Add `<PageContent />` to the workspace layout with additional padding at the top to account for the navbar (since it's now fixed to the top)

## UX Screenshots

<img width="1012" height="617" alt="image" src="https://github.com/user-attachments/assets/cc942dc6-23de-4365-a3d4-eecab813a11b" />

<img width="1012" height="617" alt="image" src="https://github.com/user-attachments/assets/09ba1d72-cc40-4af8-94c9-6f216cee7014" />
