### PR TITLE
Connect to storage service independently (Resolves #41)

### DIFF
--- a/services/file-upload/cmd/server/main.go
+++ b/services/file-upload/cmd/server/main.go
@@ -75,29 +75,8 @@ func main() {
 		}
 	})
 
-	mux.HandleFunc("POST /upload/presigned", func(w http.ResponseWriter, r *http.Request) {
-		handlerMu.RLock()
-		currentHandler := uploadHandler
-		handlerMu.RUnlock()
-
-		if currentHandler == nil {
-			http.Error(w, "Service not ready", http.StatusServiceUnavailable)
-			return
-		}
-		currentHandler.GetPresignedURL(w, r)
-	})
-
-	mux.HandleFunc("POST /upload/complete", func(w http.ResponseWriter, r *http.Request) {
-		handlerMu.RLock()
-		currentHandler := uploadHandler
-		handlerMu.RUnlock()
-
-		if currentHandler == nil {
-			http.Error(w, "Service not ready", http.StatusServiceUnavailable)
-			return
-		}
-		currentHandler.CompleteUpload(w, r)
-	})
+	mux.HandleFunc("POST /upload/presigned", uploadHandler.GetPresignedURL)
+	mux.HandleFunc("POST /upload/complete", uploadHandler.CompleteUpload)
 
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{"*"}, // modify for production


### PR DESCRIPTION
### Scenario 1: Test Immediately (within 10s of starting)
This tests the "Not Ready" state while the MinIO container is sleeping.

* **Bash/Zsh Command:**
    ```sh
    xh :8080/health
    ```
    **Expected Outcome:** An `HTTP/1.1 503 Service Unavailable` response.
    ```json
    {
        "status": "storage not ready"
    }
    ```



---
### Scenario 2: Test After 15 Seconds
This tests the "Ready" state after the MinIO container has started and the service has connected.

* **Bash/Zsh Command:**
    ```sh
    xh :8080/health
    ```
    **Expected Outcome:** An `HTTP/1.1 200 OK` response.
    ```json
    {
        "service": "file-upload",
        "status": "healthy"
    }
    ```

