### PR TITLE
feat: add frontend file upload query

### DIFF
--- a/frontend/src/client/files/health-check-query.ts
+++ b/frontend/src/client/files/health-check-query.ts
@@ -1,7 +1,6 @@
 import { queryOptions, useQuery } from '@tanstack/react-query'
 
 type HealthResponse = {
-  service: string
   status: string
 }
 
@@ -11,10 +10,8 @@ async function fetchFilesServiceHealth(): Promise<HealthResponse> {
     throw new Error('Files service healthcheck failed (bad response code)')
   }
   const data: HealthResponse = await res.json()
-  if (data.service !== 'file-upload' || data.status !== 'healthy') {
-    throw new Error(
-      `Files service healthcheck failed: service=${data.service}, status=${data.status}`,
-    )
+  if (data.status !== 'healthy') {
+    throw new Error(`Files service healthcheck failed: status=${data.status}`)
   }
   return data
 }

--- a/frontend/src/client/files/upload-query.ts
+++ b/frontend/src/client/files/upload-query.ts
@@ -1,0 +1,57 @@
+import type { FileItem } from '@/store/files/files-store'
+import { useMutation } from '@tanstack/react-query'
+
+type PresignedResponse = {
+  upload_url: string
+  key: string
+}
+
+async function uploadFile(file: FileItem, userId: string) {
+  const presignedRes = await fetch(
+    `${import.meta.env.VITE_FILES_SERVICE_URL}/upload/presigned`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content_type: file.fileType,
+        filename: file.name,
+        file_size: file.size,
+        user_id: userId,
+      }),
+    },
+  )
+
+  if (!presignedRes.ok) throw new Error('Failed to get presigned URL')
+  const { upload_url, key }: PresignedResponse = await presignedRes.json()
+
+  const uploadRes = await fetch(upload_url, {
+    method: 'PUT',
+    body: file.file,
+    headers: { 'Content-Type': file.fileType },
+  })
+
+  if (!uploadRes.ok) throw new Error('File upload failed')
+
+  const completeRes = await fetch(
+    `${import.meta.env.VITE_FILES_SERVICE_URL}/upload/complete`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        key,
+        user_id: userId,
+      }),
+    },
+  )
+
+  if (!completeRes.ok) throw new Error('Failed to notify completion')
+
+  return { key }
+}
+
+export function useFileUpload() {
+  return useMutation({
+    mutationFn: async ({ file, userId }: { file: FileItem; userId: string }) =>
+      uploadFile(file, userId),
+  })
+}

--- a/frontend/src/components/workspace/files/file-picker.tsx
+++ b/frontend/src/components/workspace/files/file-picker.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/store/files/file-picker-store'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { useFileUpload } from '@/client/files/upload-query'
 
 const PreviewFileCard: React.FC<{ file: FileItem }> = ({ file }) => {
   return (
@@ -61,6 +62,7 @@ const PreviewFileCard: React.FC<{ file: FileItem }> = ({ file }) => {
 }
 
 export default function FilePicker() {
+  const { mutate: uploadFile } = useFileUpload()
   const { isOpen, selectedFile } = useStore(filePickerStore)
   const [isDragOver, setIsDragOver] = useState(false)
 
@@ -108,9 +110,9 @@ export default function FilePicker() {
     }
   }
 
-  // TODO: Change this later to calling file-upload microservice
   const uploadQueryHandler = () => {
     if (!selectedFile) return
+    uploadFile({ file: selectedFile, userId: '23424' })
     fileItemsActions.addFile(selectedFile)
     filePickerActions.closeDialog()
   }


### PR DESCRIPTION
### Changes

Creates a query with `useMutation` to upload files from the `/workspace/:workspaceId/files`, integrating the latest changes (#51) that allow to upload files to MinIO.

Also modifies the health check query in the files page to just check the status of the service (also included in #51).