### PR TITLE
testing: add test for health check in workspace service

### DIFF
--- a/services/workspace/internal/handlers/health_test.go
+++ b/services/workspace/internal/handlers/health_test.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestHealthCheck(t *testing.T) {
+	req, err := http.NewRequest("GET", "/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	HealthCheck(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	expected := map[string]string{"status": "healthy"}
+	var actual map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &actual); err != nil {
+		t.Fatalf("could not unmarshal response body: %v", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("handler returned unexpected body: got %v want %v", actual, expected)
+	}
+}


### PR DESCRIPTION
This not only tests one of our routes, but it serves as as guide for future tests for our http routes.
closes #43 