### PR TITLE
fix: update pg volume mounts to resolve connection failures with pg v18

### DIFF
--- a/services/file-upload/compose.yaml
+++ b/services/file-upload/compose.yaml
@@ -28,7 +28,7 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
 
   file-upload-service:
     build: .

--- a/services/workspace/compose.yaml
+++ b/services/workspace/compose.yaml
@@ -13,7 +13,7 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
 
   workspace-service:
     build: .


### PR DESCRIPTION
Fixed database connection issues with the `workspace` and `file-upload` services by updating the Postgres volume mount path to match the new layout in Postgres 18. Resolves #94.
- `compose.yaml` in both services now mount at `/var/lib/postgresql` instead of `/var/lib/postgresql/data`.

## Reset to a clean state

1. Stop all running containers and remove old volumes:

```
docker compose -p file-upload down -v
docker compose -p workspace down -v
```

2. Remove any orphaned or unused volumes:

```
docker volume prune
```

3. Rebuild and restart services